### PR TITLE
Add internal class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 
 # Define the sample shared library for which we will create bindings.
-set(${sample_library}_sources datagenerator.cpp datafitter.cpp)
+set(${sample_library}_sources datagenerator.cpp datafitter.cpp internalclass.cpp)
 add_library(${sample_library} SHARED ${${sample_library}_sources})
 set_property(TARGET ${sample_library} PROPERTY PREFIX "")
 

--- a/bindings.xml
+++ b/bindings.xml
@@ -54,7 +54,11 @@
 
     <primitive-type name="double"/>
 
-    <object-type name="DataGenerator"/>
+    <value-type name="InternalClass" generate="no"/>
+
+    <object-type name="DataGenerator">
+        <modify-function signature="getInternalClass()" remove="all"/>
+    </object-type>
     <object-type name="DataFitter"/>
 
     <template name="cppvector_to_pylist_conversion">

--- a/datagenerator.cpp
+++ b/datagenerator.cpp
@@ -3,7 +3,8 @@
 #include <stdlib.h>
 #include <math.h>
 
-DataGenerator::DataGenerator()
+DataGenerator::DataGenerator() :
+    internalClass()
 {
 
 }
@@ -39,10 +40,5 @@ std::vector<double> DataGenerator::getData(std::vector<double> &x_data)
     }
 
     return y_data;
-
-}
-
-void DataGenerator::notUsedMethod()
-{
 
 }

--- a/datagenerator.h
+++ b/datagenerator.h
@@ -2,6 +2,7 @@
 #define __DATAGENERATOR_H
 
 #include <vector>
+#include "internalclass.h"
 
 class DataGenerator 
 {
@@ -13,7 +14,15 @@ public:
 
     std::vector<double> getData(std::vector<double> &x_data);
 
-    void notUsedMethod();
+    const InternalClass& getInternalClass();
+
+private:
+
+    InternalClass  internalClass;    
 
 };
+inline const InternalClass& DataGenerator::getInternalClass()
+{
+    return internalClass;
+} 
 #endif 

--- a/internalclass.cpp
+++ b/internalclass.cpp
@@ -1,0 +1,7 @@
+#include "internalclass.h"
+
+InternalClass::InternalClass() :
+    internalString("foo")
+{
+
+}

--- a/internalclass.h
+++ b/internalclass.h
@@ -1,0 +1,20 @@
+#ifndef __INTERNALCLASS_H
+#define __INTERNALCLASS_H
+
+#include <string>
+
+// This is an example of a class used internally by the 
+// C++ library that we will not need to wrap or access from
+// Python
+class InternalClass
+{
+public:
+    InternalClass();
+
+private:
+
+    std::string internalString;
+
+};
+
+#endif


### PR DESCRIPTION
Adds an example class in the C++ library that we do not need to wrap for Python.